### PR TITLE
fix: Add workarounds for selenium bug

### DIFF
--- a/src/selenium/basePage.js
+++ b/src/selenium/basePage.js
@@ -44,6 +44,10 @@ const BasePage = {
     return el.click();
   },
 
+  jsClick(el) {
+    return this.driver.executeScript("arguments[0].click();", el);
+  },
+
   toggleStarredButton: function() {
     return this.find(By.id('starred')).then(this.click);
   },
@@ -56,8 +60,7 @@ const BasePage = {
       const promElem = new Promise(function(resolve, reject) {
         self.find(By.id(sessionId)).then(function(el) {
           // TODO: Revert when fixed. Workaround for https://github.com/angular/protractor/issues/3093
-          const element = el.findElement(By.className('bookmark'));
-          self.driver.executeScript("arguments[0].click();", element).then(function() {
+          self.jsClick(el.findElement(By.className('bookmark'))).then(function() {
             resolve('done');
           });
         });
@@ -219,10 +222,9 @@ const BasePage = {
     const pageVertScrollOffset = 'return window.scrollY';
 
     return new Promise(function(resolve) {
-      self.find(By.id(sessionTitleId)).then(self.click).then(function() {
-        const element = self.find(By.id(sessionDetailId)).findElement(By.css('a'));
-        // TODO: Revert when fixed. Workaround for https://github.com/angular/protractor/issues/3093
-        self.driver.executeScript("arguments[0].click();", element).then(self.getPageUrl.bind(self)).then(function(url) {
+      // TODO: Revert when fixed. Workaround for https://github.com/angular/protractor/issues/3093
+      self.jsClick(self.find(By.id(sessionTitleId))).then(function() {
+        self.jsClick(self.find(By.id(sessionDetailId)).findElement(By.css('a'))).then(self.getPageUrl.bind(self)).then(function(url) {
           self.driver.executeScript(pageVertScrollOffset).then(function(height) {
             resolve(height > 0 && url.search('speakers') !== -1);
           });

--- a/src/selenium/basePage.js
+++ b/src/selenium/basePage.js
@@ -55,7 +55,9 @@ const BasePage = {
     sessionIds.forEach(function(sessionId) {
       const promElem = new Promise(function(resolve, reject) {
         self.find(By.id(sessionId)).then(function(el) {
-          el.findElement(By.className('bookmark')).then(self.click).then(function() {
+          // TODO: Revert when fixed. Workaround for https://github.com/angular/protractor/issues/3093
+          const element = el.findElement(By.className('bookmark'));
+          self.driver.executeScript("arguments[0].click();", element).then(function() {
             resolve('done');
           });
         });
@@ -218,7 +220,9 @@ const BasePage = {
 
     return new Promise(function(resolve) {
       self.find(By.id(sessionTitleId)).then(self.click).then(function() {
-        self.find(By.id(sessionDetailId)).findElement(By.css('a')).click().then(self.getPageUrl.bind(self)).then(function(url) {
+        const element = self.find(By.id(sessionDetailId)).findElement(By.css('a'));
+        // TODO: Revert when fixed. Workaround for https://github.com/angular/protractor/issues/3093
+        self.driver.executeScript("arguments[0].click();", element).then(self.getPageUrl.bind(self)).then(function(url) {
           self.driver.executeScript(pageVertScrollOffset).then(function(height) {
             resolve(height > 0 && url.search('speakers') !== -1);
           });


### PR DESCRIPTION
Tests are working correctly on local machine,
but in Travis, the click is obscured by overlapping
element because it first scrolls the element into
view and then tries to click on it.

The workaround should be reverted once it is fixed

Follow up of #2172 
Fixes #2128 