### PR TITLE
fix: Simplifies the form, set the default api to v2, pre-selected the desired options, text fixes

### DIFF
--- a/src/www/index.html
+++ b/src/www/index.html
@@ -292,7 +292,7 @@
         </ul> -->
         <!-- changes-2 removed till here -->
         <!-- changes-2 added from here -->
-        <ul style="list-style-type:none;postion: relative;">
+        <ul style="list-style-type:none; position: relative;">
           <li>
             <input name="session" required="" type="radio" value="single" id="single">
             <label for="single">Single</label>
@@ -308,34 +308,20 @@
         <!-- Map Integration-->
         <label>Choose Map Integration</label>
 
-        <ul style="list-style-type:none;postion: relative;">
+        <ul style="list-style-type:none; position: relative;">
           <li>
             <input id="google" name="map" type="radio" value="googleMap">
-            <label for="google">Google_Map</label>
+            <label for="google">Google Map</label>
           </li>
 
           <li>
             <input id="open_street" name="map" type="radio" value="openStreetMap">
-            <label for="open_street">Open_Street_Map</label>
-          </li>
-        </ul>
-
-      
-        <label>Choose your API version</label>
-        <ul style="list-style-type:none">
-          <!--<li><input type="radio" name="datasource" value="mockjson"> Default mock API </input></li>-->
-          <li>
-            <input id="version1" name="apiVersion" type="radio" value="api_v1">
-            <label for="version1">API_v1</label>
-          </li>
-          <li>
-            <input id="version2" name="apiVersion" type="radio" value="api_v2">
-            <label for="version2">API_v2</label>
+            <label for="open_street">Open Street Map</label>
           </li>
         </ul>
 
         <!-- changes-2 added till here -->
-        <label>Choose your data source</label>
+        <label>Choose Your Data Source</label>
         <ul style="list-style-type:none">
           <!--<li><input type="radio" name="datasource" value="mockjson"> Default mock API </input></li>-->
           <li id="uploadJSON">
@@ -344,15 +330,15 @@
           </li>
           <li id="endpointAPI">
             <input name="datasource" id="eventapi" type="radio" value="eventapi">
-            <label for="endpointAPI">API endpoint of event on OpenEvent</label>
+            <label for="endpointAPI">API Endpoint</label>
           </li>
         </ul>
         <section id="eventapi-input" style="display:none;">
-          <label for="apiendpoint">Link to Open Event API endpoint</label>
+          <label style="font-weight: 400;" for="apiendpoint">Link to Open Event API Endpoint</label>
           <input class="form-control" id="apiendpoint" name="apiendpoint" required="true" type="url">
         </section>
         <section id="jsonupload-input" style="display:none;">
-          <label for="siofu_input">Zip file containing resources for the event</label>
+          <label style="font-weight: 400;" for="siofu_input">Zip file containing resources for the event</label>
           <input accept="application/zip" class="form-control" id="siofu_input" name="singlefileUpload" required="true" type="file">
           <div id="message">
             <p>File has been successfully uploaded</p>
@@ -392,14 +378,14 @@
           <input id="enable-google-analytics" title="Enable Google Analytics" type="checkbox">
           <label for="enable-google-analytics">Enable Google Analytics</label>
           <div id="ganalytics-id-container" style="display: none">
-            <input class="form-control" style="width: 49.2%; display: inline" id="ganalytics-id" placeholder="google analytics id" type="text">
+            <input class="form-control" style="width: 49.2%; display: inline" id="ganalytics-id" placeholder="Google Analytics ID" type="text">
           </div>
         </section>
         <section>
           <input id="enable-google-calendar" title="Enable Google Calendar" type="checkbox"> <label for="enable-google-calendar">Enable Google Calendar</label>
           <div id="gcalendar-id-container" style="display: none">
-            <input class="form-control" style="width: 100%; display: inline" id="gcalendar-key" placeholder="google calendar API Key" type="text">
-            <input class="form-control" style="width: 100%; display: inline; margin-top: 5px" id="gcalendar-id" placeholder="google calendar Client ID" type="text">
+            <input class="form-control" style="width: 100%; display: inline" id="gcalendar-key" placeholder="Google Calendar API Key" type="text">
+            <input class="form-control" style="width: 100%; display: inline; margin-top: 5px" id="gcalendar-id" placeholder="Google Calendar Client ID" type="text">
           </div>
         </section>
         <section>
@@ -413,7 +399,7 @@
           <div id="status" style="margin-bottom:10px;"></div><a id="aLog" style="cursor:pointer;">-Logs-</a>
           <pre id="buildLog" style="display:none;">
                     </pre><br>
-          <button class="download btn btn-default" disabled id="btnGenerate" style="margin-top:7px" title="Upload zip or use API mode to enable" type="button" value="Validate">GENERATE WEBAPP</button> <button class="download btn btn-default" id="btnLive" type="button">PREVIEW</button> <button class="download btn btn-default" id="btnDownload" type="button">DOWNLOAD</button> <a class="btn btn-default" id="deploy" style="display:none">DEPLOY</a>
+          <button class="download btn btn-default" id="btnGenerate" style="margin-top:7px" title="Upload zip or use API mode to enable" type="button" value="Validate">GENERATE WEBAPP</button> <button class="download btn btn-default" id="btnLive" type="button">PREVIEW</button> <button class="download btn btn-default" id="btnDownload" type="button">DOWNLOAD</button> <a class="btn btn-default" id="deploy" style="display:none">DEPLOY</a>
         </center>
       </div>
     </form>

--- a/src/www/js/form.js
+++ b/src/www/js/form.js
@@ -490,11 +490,14 @@ function updateStatus(statusMsg) {
 }
 
 function initialState() {
+  $('#expandable').prop('checked', true);
+  $('#open_street').prop('checked', true);
   $('input:radio[name="datasource"]').prop('checked', false);
+  $("#eventapi").prop('checked', true);
+  $('#eventapi-input').show(100);
   $('#upload-ftp').prop('checked', false);
   $('#enable-google-analytics').prop('checked', false);
   $('#enable-google-calendar').prop('checked', false);
-  $('#btnGenerate').prop('disabled', true);
   uploadFinished = false;
 }
 
@@ -523,6 +526,8 @@ function getFile() {
 function getData(initValue) {
   const data = initValue;
   const formData = $('#form').serializeArray();
+  
+  data.apiVersion= 'api_v2';
 
   formData.forEach(function(field) {
     if (field.name === 'email') {
@@ -542,9 +547,6 @@ function getData(initValue) {
     }
     if (field.name === 'session') {
       data.sessionMode = field.value;
-    }
-    if (field.name === 'apiVersion') {
-      data.apiVersion = field.value;
     }
     if (field.name === 'map') {
       data.map = field.value;


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

[Performed as a part of Codeheat]

#### Short description of what this resolves:
This commit resolves the desired changes in issue #2335. Change of spellings & font-weight(bold), Pre-selecting Expandable & Open Street Map and getting rid of the "Choose your API version" by setting it to the default v2 as desired.

Though I was not able to deploy the app because to deploy it to either heroku/any other service, either they are paid or need a credit card(for heroku redis) and I don't have that.. 

Here's the link to the updated app's recording (as suggested): https://open-event-wsgen-2335.vercel.app/248182f3-1663-4b29-b161-e4612701e35d.webm

[One of the solutions to view the code working can be that you can give me a slot in which you'll be reviewing the commit and then I'll be more than happy to attach a link to ngrok so that the commit be tested. Please guide in case any other way out is possible.]

#### Changes proposed in this pull request:

- Change postion: relative to position: relative,
- Got rid of underscores and bold to unbold,
- Removed the "Choose your API version" and set it default to data.apiVersion= 'api_v2'; in the script,
- As now auto-select to api endpoint has been done, the field to the link of it is also set enabled by default, hence the generate webapp button also. (By script's initialState)
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2335 
