### PR TITLE
fix: Make Speaker description width 100% for 992px to 1200px screen

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1396,7 +1396,7 @@ a {
     }
 
     .speaker-description {
-      padding-top: 40px;
+      padding-top: 20px;
       text-align: center;
       width: 100%;
     }

--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1396,6 +1396,7 @@ a {
     }
 
     .speaker-description {
+      padding-top:40px;
       text-align: center;
       width: 100%;
     }

--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1397,7 +1397,7 @@ a {
 
     .speaker-description {
       text-align: center;
-      width: 50%;
+      width: 100%;
     }
   }
 }

--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1396,7 +1396,7 @@ a {
     }
 
     .speaker-description {
-      padding-top:40px;
+      padding-top: 40px;
       text-align: center;
       width: 100%;
     }


### PR DESCRIPTION
Previously it was of width 50% by default ............ according to this issue I made it 100%.


<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->


Fixes #2322
