### PR TITLE
fix: Remove unwanted space in speaker name list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ configmap.yml.secret
 .tool-versions
 .env
 .vscode
+
+package-lock.json

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -212,7 +212,7 @@
                             <div class="speaker-short-info">
                               <ul class="speaker-name-list">
                                 {{#speakers_list}}
-                                  {{name}}{{#if organisation}}&nbsp;({{position}} {{organisation}}){{/if}}{{#if @last}}{{else}},{{/if}}
+                                    {{name}}{{#if organisation}}&nbsp;({{#if position}}{{position}}&nbsp;{{/if}}{{organisation}}){{/if}}{{#if @last}}{{else}},{{/if}}
                                 {{/speakers_list}}
                               </ul>
                               <ul class="speaker-name-list">{{type}}</ul>

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -206,7 +206,7 @@
                                   <div class="speaker-short-info">
                                     <ul class="speaker-name-list">
                                       {{#speakers_list}}
-                                        {{name}}{{#if organisation}}&nbsp;({{position}} {{organisation}}){{/if}}{{#if @last}}{{else}},{{/if}}
+                                        {{name}}{{#if organisation}}&nbsp;({{#if position}}{{position}}&nbsp;{{/if}}{{organisation}}){{/if}}{{#if @last}}{{else}},{{/if}}
                                       {{/speakers_list}}
                                     </ul>
                                     <ul class="speaker-name-list">{{type}}</ul>


### PR DESCRIPTION
Fix: Remove unwanted space after round brackets in speaker name list if speaker position(job title) is not specified

- Add a conditional to check if position is passed

Fixes #2249 