### PR TITLE
fix: Move the video to the top when session is expanded

### DIFF
--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -221,26 +221,25 @@
                         </div>
                       </h4>
                       <div id="desc-{{session_id}}" class="collapse">
-                        {{{description}}}
-                        {{#if ../../../gcalendar.enabled}}
-                          <button class="btn btn-default add-to-calendar-button" onclick="main.handleAuthClick('{{title}}','{{location}}','{{calendarStart}}','{{calendarEnd}}','{{../../../eventurls.timezone}}','{{description}}')">Add to Calendar</button>
-                        {{/if}}
-                        {{#ifcontains audio "mp3"}}
-                          <audio controls="" preload="none" id="audio-block">
-                            <source src="{{ audio }}">
-                          </audio>
-                        {{/ifcontains}}
-                        {{#ifcontains audio "aac"}}
-                          <audio controls="" preload="none" id="audio-block">
-                            <source src="{{ audio }}">
-                          </audio>
-                        {{/ifcontains}}
-                        {{#ifvalue description notequals=""}}
-                          <hr class="clear-both">
-                        {{/ifvalue}}
                         <div id="speaker-{{session_id}}" class="session-speakers-list"
-                          aria-expanded="false"
-                          aria-controls="desc-{{session_id}}">
+                          aria-expanded="false" aria-controls="desc-{{session_id}}">
+                            {{{description}}}
+                            {{#if ../../../gcalendar.enabled}}
+                            <button class="btn btn-default add-to-calendar-button" onclick="main.handleAuthClick('{{title}}','{{location}}','{{calendarStart}}','{{calendarEnd}}','{{../../../eventurls.timezone}}','{{description}}')">Add to Calendar</button>
+                            {{/if}}
+                            {{#ifcontains audio "mp3"}}
+                            <audio controls="" preload="none" id="audio-block">
+                                <source src="{{ audio }}">
+                            </audio>
+                            {{/ifcontains}}
+                            {{#ifcontains audio "aac"}}
+                            <audio controls="" preload="none" id="audio-block">
+                                <source src="{{ audio }}">
+                            </audio>
+                            {{/ifcontains}}
+                            {{#ifvalue description notequals=""}}
+                            <hr class="clear-both">
+                            {{/ifvalue}}
                           {{#each speakers_list}}
                             <div class="margin-down-10">
                               <a href="speakers.html#{{nameIdSlug}}">

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -215,23 +215,23 @@
                               </div>
                             </div>
                             <div id="desc-{{session_id}}" class="collapse">
-                              {{{description}}}
-                              {{#if ../../../gcalendar.enabled}}
-                                <button class="btn btn-default add-to-calendar-button" onclick="main.handleAuthClick('{{title}}','{{location}}','{{calendarStart}}','{{calendarEnd}}','{{../../../eventurls.timezone}}','{{description}}')">Add to Calendar</button>
-                              {{/if}}
-                              {{#ifcontains audio "mp3"}}
-                                <audio controls="" preload="none" id="audio-block">
-                                  <source src="{{ audio }}">
-                                </audio>
-                              {{/ifcontains}}
-                              {{#ifcontains audio "aac"}}
-                                <audio controls="" preload="none" id="audio-block">
-                                  <source src="{{ audio }}">
-                                </audio>
-                              {{/ifcontains}}
-                              <hr class="clear-both">
                               <div id="speaker-{{session_id}}" class="session-speakers-list" aria-expanded="false"
                                 aria-controls="desc-{{session_id}}">
+                                {{{description}}}
+                                {{#if ../../../gcalendar.enabled}}
+                                    <button class="btn btn-default add-to-calendar-button" onclick="main.handleAuthClick('{{title}}','{{location}}','{{calendarStart}}','{{calendarEnd}}','{{../../../eventurls.timezone}}','{{description}}')">Add to Calendar</button>
+                                {{/if}}
+                                {{#ifcontains audio "mp3"}}
+                                    <audio controls="" preload="none" id="audio-block">
+                                    <source src="{{ audio }}">
+                                    </audio>
+                                {{/ifcontains}}
+                                {{#ifcontains audio "aac"}}
+                                    <audio controls="" preload="none" id="audio-block">
+                                    <source src="{{ audio }}">
+                                    </audio>
+                                {{/ifcontains}}
+                                <hr class="clear-both">
                                 {{#speakers_list}}
                                   <div class="session-speakers-less">
                                     <p class="session-speakers">


### PR DESCRIPTION
### **Fixes #2253**

    - Earlier when the session was expanded the video rendered below the description
    - This commit moves the video to the top and the other elements render in the same order when session is expanded
    - Move the div to the top which now contains all the elements of the session when expanded

### **Before the changes**
![image](https://user-images.githubusercontent.com/51796498/97465434-0a98a080-1968-11eb-99bc-80f2f3e9bf46.png)


### **After the changes**
![image](https://user-images.githubusercontent.com/51796498/97465159-c73e3200-1967-11eb-930a-a797c0557782.png)
