### PR TITLE
fix: Enable open sidebar filter links in a new tab

### DIFF
--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -331,7 +331,7 @@
                 {{#each roomsnames}}
                   <div class="room-info">
                     <span class="titlecolor room-titlecolor"></span>
-                    <span class="room-name">{{this}}</span>
+                    <span class="room-name"><a href="#{{this}}">{{this}}</a></span>
                   </div>
                 {{/each}}
               </div>
@@ -341,7 +341,7 @@
                 {{#if title}}
                 <div class="track-info">
                   <span style="background-color: {{color}};" class="titlecolor"></span>
-                  <span class="track-name">{{title}}</span>
+                  <span class="track-name"><a href="#{{title}}">{{title}}</a></span>
                 </div>
                 {{/if}}
                 {{/tracknames}}

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -478,7 +478,7 @@
                 {{#each roomsnames}}
                   <div class="room-info">
                     <span class="titlecolor room-titlecolor"></span>
-                    <span class="room-name">{{this}}</span>
+                    <span class="room-name"><a href="#{{this}}">{{this}}</a></span>
                   </div>
                   {{/each}}
                 </div>
@@ -490,7 +490,7 @@
                     {{#if title}}
                     <div class="track-info">
                       <span style="background-color: {{color}};" class="titlecolor"></span>
-                      <span class="track-name">{{title}}</span>
+                      <span class="track-name"><a href="#{{title}}">{{title}}</a></span>
                     </div>
                     {{/if}}
                   {{/tracknames}}

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -322,7 +322,7 @@
                       {{#if title}}
                         <div class="track-info">
                           <span style="background-color: {{color}};" class="titlecolor"></span>
-                          <span class="track-name">{{title}}</span>
+                          <span class="track-name"><a href="#{{title}}">{{title}}</a></span>
                         </div>
                       {{/if}}
                     {{/tracknames}}
@@ -332,7 +332,7 @@
                     {{#each roomsnames}}
                       <div class="room-info">
                         <span class="titlecolor room-titlecolor"></span>
-                        <span class="room-name">{{this}}</span>
+                        <span class="room-name"><a href="#{{this}}">{{this}}</a></span>
                       </div>
                     {{/each}}
                 </div>


### PR DESCRIPTION
### **Fixes #2139**

- Earlier it was not possible to open the sidebar filter links as real links in a new tab
- Enclose the links inside an anchor tag to get the out of the box functionality of open in new tab

### **Before the change**
![image](https://user-images.githubusercontent.com/51796498/97529594-44a08b80-19d6-11eb-8bf9-a1edb559cc49.png)

### **After the change**
![image](https://user-images.githubusercontent.com/51796498/97529654-600b9680-19d6-11eb-8631-882f5bc95742.png)
