### PR TITLE
fix: Make width of sessions uniform for schedule and tracks pages

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1079,7 +1079,6 @@ a {
   }
 
   margin-right: 10px;
-  display: inline-block;
   vertical-align: text-top;
 }
 


### PR DESCRIPTION
### **Fixes #2137**
- Earlier the session div was inline-block in the schedule page
- Make it block to match with tracks page

### **Before the change**
![image](https://user-images.githubusercontent.com/51796498/97576701-83edcd00-1a14-11eb-82d4-872167fec8fb.png)

### **After the change**
![image](https://user-images.githubusercontent.com/51796498/97576996-d9c27500-1a14-11eb-9457-f0bd915b714e.png)
