### PR TITLE
fix: the layout of the speaker bio

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1397,7 +1397,7 @@ a {
 
     .speaker-description {
       text-align: center;
-      width: 50%;
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
### description-
aligned the speaker name and their bio.

### Fixed-
#2158 

### screenshot before-
![bug](https://user-images.githubusercontent.com/65535360/98013964-0f0a0100-1e21-11eb-8feb-207471412fbf.PNG)


### screenshot after-
![12](https://user-images.githubusercontent.com/65535360/98013907-fb5e9a80-1e20-11eb-8e5c-629cd4a0b75f.PNG)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
center the speaker bio description
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

@iamareebjamal  and @mariobehling   can you review 
