### PR TITLE
fix: Align search bar in the date-list container

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -2469,3 +2469,14 @@ a.skip:hover {
     display: none;
   }
 }
+
+.date-list-search-filter {
+
+  label {
+    display: inline;
+
+    .fa {
+      margin-top: 13px;
+    }
+  }
+}

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -109,7 +109,7 @@
                    </li>
               </ul>
             </span>
-            <div class="filter search-filter search-filter-room">
+            <div class="filter search-filter search-filter-room date-list-search-filter">
              <label for="search-input"><i class="fa fa-search" aria-hidden="true"></i></label>
              <input class="fossasia-filter" type="text" placeholder="Search">
             </div>

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -118,7 +118,7 @@
             <li> <a href="#" class="export-pdf"> Download as pdf </a> </li>
           </ul>
         </span>
-        <span class="filter search-filter search-filter-schedule">
+        <span class="filter search-filter search-filter-schedule date-list-search-filter">
          <label for="search-input"><i class="fa fa-search" aria-hidden="true"></i></label>
          <input class="fossasia-filter" type="text" placeholder="Search">
         </span>

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -101,7 +101,7 @@
                 </li>
             </ul>
           </span>
-          <div class="filter search-filter search-filter-room">
+          <div class="filter search-filter search-filter-room date-list-search-filter">
                <label for="search-input"><i class="fa fa-search" aria-hidden="true"></i></label>
                <input class="fossasia-filter" type="text" placeholder="Search">
          </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Aligns the search bar which was out of place earlier.
### **Before the change:**
![image](https://user-images.githubusercontent.com/51796498/98388472-d5333780-2078-11eb-8072-3865d32c96e9.png)

### **After the change:**
![image](https://user-images.githubusercontent.com/51796498/98388850-4541bd80-2079-11eb-9757-74f1872c9e4d.png)

#### Changes proposed in this pull request:

- Make label inline so that input field doesn't move below and set the margins accordingly
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2214
