### PR TITLE
fix: Change path for unzipper as a relative path in place of absolute path

### DIFF
--- a/src/backend/dist.js
+++ b/src/backend/dist.js
@@ -480,7 +480,7 @@ module.exports = {
     });
 
     unzipper.extract({
-      path: appPath + '/zip'
+      path: 'dist/' + appFolder + '/zip'
     });
 
     unzipper.on('extract', function(log) {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Generate web app by uploading sample zip as earlier unzipper was not able to locate the zip file which was uploaded.

![image](https://user-images.githubusercontent.com/51796498/98778090-d5845780-2417-11eb-9887-0efa29e9a25e.png)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2390
